### PR TITLE
fix team array overflow

### DIFF
--- a/src/Components/TeamSelect.js
+++ b/src/Components/TeamSelect.js
@@ -23,7 +23,9 @@ const TeamSelect = () => {
 // console.log(getUrl())
 
     const handleClick = (e) => {
-        setTeam( [...team, e ])
+        team.length < 4 ? 
+            setTeam( [...team, e ])
+            : team.shift() && setTeam( [...team, e ]) // remove first element and add new last element
     }  
 
     return(


### PR DESCRIPTION
The team array keep accepting new element dispite not having room anymore, causing overflowing of the arry.

I updated the handleclick with a ternary that say, if the array reach 4 element, remove the first element then add a new last element.